### PR TITLE
ci: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material "mkdocstrings[python]" mkdocs-minify-plugin mike
+          # Install the project itself to allow mkdocstrings to find modules
+          pip install -e ./dev
+
+      - name: Deploy to GitHub Pages
+        run: |
+          # Deploy 'latest' version
+          mike deploy --push --update-aliases latest
+          # Set 'latest' as default
+          mike set-default --push latest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Crystalyse Documentation
 site_description: Autonomous AI agents for accelerated inorganic materials design through natural language interfaces
-site_url: https://crystalyse-ai.readthedocs.io/
+site_url: https://ryannduma.github.io/CrystaLyse.AI/
 repo_url: https://github.com/ryannduma/CrystaLyse.AI
 repo_name: ryannduma/CrystaLyse.AI
 edit_uri: edit/main/docs/


### PR DESCRIPTION
## Summary
This PR sets up a continuous deployment pipeline for the project documentation using GitHub Actions and GitHub Pages.

## Changes
- **Workflow**: Added [.github/workflows/docs.yml](cci:7://file:///home/ryan/updatecrystalyse/CrystaLyse.AI/.github/workflows/docs.yml:0:0-0:0) which:
  - Triggers on pushes to `main`.
  - Builds the documentation using `mkdocs`.
  - Deploys to the `gh-pages` branch using `mike` to support versioning (e.g., `latest`, `v1.0`).
- **Configuration**: Updated [mkdocs.yml](cci:7://file:///home/ryan/updatecrystalyse/CrystaLyse.AI/mkdocs.yml:0:0-0:0) `site_url` to the correct GitHub Pages URL.

## Impact
Documentation will now be automatically published to `https://ryannduma.github.io/CrystaLyse.AI/` on every merge to main.