### PR TITLE
fix: Ensure Chemeleon model uses GPU on HPC systems

### DIFF
--- a/dev/crystalyse/tools/chemeleon/predictor.py
+++ b/dev/crystalyse/tools/chemeleon/predictor.py
@@ -83,6 +83,7 @@ def _load_model(task: str = "csp", checkpoint_path: str | None = None, prefer_gp
         diffusion_module = DiffusionModule.load_from_checkpoint(
             checkpoint_path, map_location=device
         )
+        diffusion_module.to(device)  # Ensure model is on correct device
     except TypeError as e:
         if "optimiser_configs" in str(e):
             logger.info("Loading model with optimiser_configs compatibility mode")
@@ -126,6 +127,14 @@ def _load_model(task: str = "csp", checkpoint_path: str | None = None, prefer_gp
             raise e
 
     diffusion_module.eval()
+
+    # Log actual device for verification (helps debug HPC GPU issues)
+    try:
+        actual_device = next(diffusion_module.parameters()).device
+        logger.info(f"Model verified on device: {actual_device}")
+    except StopIteration:
+        logger.warning("Could not verify model device (no parameters found)")
+
     _model_cache[cache_key] = diffusion_module
 
     return diffusion_module

--- a/pypi-v2/src/crystalyse/tools/chemeleon/predictor.py
+++ b/pypi-v2/src/crystalyse/tools/chemeleon/predictor.py
@@ -81,6 +81,7 @@ def _load_model(task: str = "csp", checkpoint_path: Optional[str] = None, prefer
             checkpoint_path,
             map_location=device
         )
+        diffusion_module.to(device)  # Ensure model is on correct device
     except TypeError as e:
         if "optimiser_configs" in str(e):
             logger.info("Loading model with optimiser_configs compatibility mode")
@@ -121,6 +122,14 @@ def _load_model(task: str = "csp", checkpoint_path: Optional[str] = None, prefer
             raise e
 
     diffusion_module.eval()
+
+    # Log actual device for verification (helps debug HPC GPU issues)
+    try:
+        actual_device = next(diffusion_module.parameters()).device
+        logger.info(f"Model verified on device: {actual_device}")
+    except StopIteration:
+        logger.warning("Could not verify model device (no parameters found)")
+
     _model_cache[cache_key] = diffusion_module
 
     return diffusion_module


### PR DESCRIPTION
The model was not being moved to GPU for student tests on CX3 notebooks. Added explicit .to(device) call and device verification logging to help debug HPC GPU issues.

## Description

Brief description of what this PR does.

Fixes # (issue number, if applicable)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or tooling update

## Testing

Describe how you tested these changes:

- [X] Ran `pytest tests/ -v` locally
- [ ] Ran `pre-commit run --all-files`
- [ ] Added new tests for new functionality
- [ ] Tested manually (describe below)

**Test details:**

## Checklist

- [ ] My code follows the project's style guidelines (ruff format/lint)
- [X] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
- [ ] I have updated CLAUDE.md if this changes development workflows