### PR TITLE
fix(torch): cap torch<2.11 to keep CUDA 12.x drivers on the GPU path

### DIFF
--- a/dev/chemistry-creative-server/pyproject.toml
+++ b/dev/chemistry-creative-server/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     # Pinned to v0.1.2 which includes fix for missing subpackages
     "chemeleon-dng @ git+https://github.com/hspark1212/chemeleon-dng.git@v0.1.2",
     "mace-torch>=0.3.0",
-    "torch>=2.1.0",
+    # Cap below 2.11 — torch 2.11 requires CUDA 13 drivers. See dev/pyproject.toml.
+    "torch>=2.1.0,<2.11",
     "pymatgen>=2.4.1.0",
 ]
 

--- a/dev/chemistry-unified-server/pyproject.toml
+++ b/dev/chemistry-unified-server/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     # Chemistry libraries (also declared in crystalyse, but explicit here for clarity)
     "pymatgen",
     "ase",
-    "torch",
+    # Cap below 2.11 — torch 2.11 requires CUDA 13 drivers. See dev/pyproject.toml.
+    "torch<2.11",
     "numpy",
     "smact",
     "mace-torch",

--- a/dev/pyproject.toml
+++ b/dev/pyproject.toml
@@ -24,7 +24,16 @@ dependencies = [
     # Can use GitHub source for now until PyPI package is published
     "chemeleon-dng @ git+https://github.com/hspark1212/chemeleon-dng.git@v0.1.2",
 
-    "torch>=2.1.0",
+    # Cap below 2.11 because torch 2.11.0 bumped its CUDA runtime to 13.0,
+    # which requires an NVIDIA driver new enough to support CUDA 13 (driver
+    # reporting maxCuda >= 13.0). Drivers pinned at CUDA 12.x — which is the
+    # common HPC case, e.g. NVIDIA 550.x maxes out at CUDA 12.4 — fall back
+    # silently to CPU and every Chemeleon / MACE call takes the slow path.
+    # torch 2.10.x still ships cu12x wheels on PyPI and works on any driver
+    # that supports CUDA >= 12.0, so it covers a much broader range of
+    # real-world machines. Raise this ceiling once the CUDA 13 driver floor
+    # is actually the common case in the communities we ship to.
+    "torch>=2.1.0,<2.11",
     "smact>=2.7.0",
     "mace-torch>=0.3.0",
 ]

--- a/dev/tests/contract/test_torch_version_cap.py
+++ b/dev/tests/contract/test_torch_version_cap.py
@@ -1,0 +1,122 @@
+"""
+Contract test: no pyproject.toml in this repo may declare an uncapped torch dep.
+
+torch 2.11.0 bumped its CUDA runtime to 13.0, which requires an NVIDIA driver
+new enough to support CUDA 13 (roughly driver 555+). On any machine whose
+driver tops out at CUDA 12.x — which is still the common case on HPC clusters
+and shared workstations — torch 2.11 fails to initialise CUDA and both
+Chemeleon and MACE silently fall back to CPU. Every structure generation and
+energy calculation then takes the slow path.
+
+Until CUDA 13 drivers are the common case in our target communities, every
+torch dep declaration in this repo must be capped at ``<2.11``. This test
+walks every ``pyproject.toml`` in the repo (both ``dev/`` active source and
+``pypi-v2/`` release snapshot, plus their MCP-server subprojects and the
+legacy repo-root wrapper) and asserts the cap is present.
+
+If you need to raise or remove the cap, update the cap expression in all
+affected pyproject.toml files *together* so this test stays green, and make
+sure the target driver floor is documented in the commit message.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# Project root is parent of dev/
+PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
+
+
+def _discover_pyproject_files() -> list[Path]:
+    """Return every pyproject.toml in the repo except those under vendored dirs.
+
+    We deliberately include ``pypi-v2/`` — that's the release snapshot and
+    ships to PyPI — and every MCP-server subproject. The only exclusions are
+    build caches / editable install artefacts / reference repo clones kept
+    alongside CrystaLyse.AI.
+    """
+    excluded = {".egg-info", "__pycache__", "build", "dist", ".mypy_cache"}
+    results: list[Path] = []
+    for path in PROJECT_ROOT.rglob("pyproject.toml"):
+        if any(part in excluded or part.endswith(".egg-info") for part in path.parts):
+            continue
+        results.append(path)
+    return sorted(results)
+
+
+# Matches a torch declaration line inside a pyproject dependency list. Captures:
+#   group 1: the version spec that follows the literal "torch" dep name (may be empty).
+# Explicitly excludes "mace-torch", "torch-geometric", "torch-ema", "pytorch-*",
+# etc., by requiring the preceding character to be a quote rather than a dash.
+_TORCH_DEP_RE = re.compile(
+    r"""
+    (?:^|[\s,])                  # start of line or after whitespace/comma
+    ["']                         # opening quote of the dep string
+    torch                        # the literal name — must NOT be preceded by '-'
+    (?P<spec>[^"']*)             # everything up to the closing quote = version spec
+    ["']                         # closing quote
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+
+def _torch_dep_specs_in(path: Path) -> list[str]:
+    """Return every top-level ``torch`` dep declaration found in ``path``.
+
+    Filters out comment lines so we don't pick up tombstone comments that
+    happen to quote the dep string.
+    """
+    specs: list[str] = []
+    for raw_line in path.read_text().splitlines():
+        stripped = raw_line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        for match in _TORCH_DEP_RE.finditer(raw_line):
+            # Guard against mace-torch / pytorch-lightning / torch-geometric etc.
+            # where the capture would still technically match if we weren't careful:
+            # _TORCH_DEP_RE requires the dep name to be exactly "torch" followed by
+            # a version spec or quote, so "mace-torch" can't match — the preceding
+            # 'e-' isn't in the character class. Still, belt-and-suspenders:
+            # reject anything whose spec starts with "-" (e.g. "torch-geometric").
+            spec = match.group("spec")
+            if spec.startswith("-"):
+                continue
+            specs.append(spec)
+    return specs
+
+
+def test_torch_dep_discovery_finds_something() -> None:
+    """Sanity: we expect at least the dev/pyproject.toml root-level torch dep.
+
+    If this fails, either the regex is wrong or the dev pyproject has been
+    restructured in a way the rest of this test can't reason about.
+    """
+    dev_py = PROJECT_ROOT / "dev" / "pyproject.toml"
+    assert dev_py.exists(), f"dev/pyproject.toml not found at {dev_py}"
+    specs = _torch_dep_specs_in(dev_py)
+    assert specs, f"no torch dep parsed out of {dev_py} — regex or layout drifted"
+
+
+@pytest.mark.parametrize("pyproject_path", _discover_pyproject_files(), ids=str)
+def test_no_uncapped_torch_dep(pyproject_path: Path) -> None:
+    """Every torch dep in every pyproject.toml must cap at ``<2.11``.
+
+    Rationale: torch 2.11 bumped to CUDA 13 runtime, which breaks GPU on any
+    driver that tops out at CUDA 12.x (still the common HPC / workstation
+    case). See the module docstring.
+    """
+    specs = _torch_dep_specs_in(pyproject_path)
+    if not specs:
+        pytest.skip(f"no torch dep in {pyproject_path.relative_to(PROJECT_ROOT)}")
+
+    for spec in specs:
+        assert "<2.11" in spec or "<2.10" in spec or "==2.10" in spec or "==2.9" in spec, (
+            f"{pyproject_path.relative_to(PROJECT_ROOT)} declares an uncapped torch dep "
+            f'("torch{spec}"). torch >= 2.11 requires a CUDA 13 NVIDIA driver and '
+            f"silently falls back to CPU on every CUDA 12.x driver we target. "
+            f'Cap to "<2.11" or update this test if the cap is being deliberately '
+            f"lifted."
+        )

--- a/pypi-v2/mcp-servers/chemistry-creative-server/pyproject.toml
+++ b/pypi-v2/mcp-servers/chemistry-creative-server/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     # Pinned to v0.1.2 which includes fix for missing subpackages
     "chemeleon-dng @ git+https://github.com/hspark1212/chemeleon-dng.git@v0.1.2",
     "mace-torch>=0.3.0",
-    "torch>=2.1.0",
+    # Cap below 2.11 — torch 2.11 requires CUDA 13 drivers. See pypi-v2/pyproject.toml.
+    "torch>=2.1.0,<2.11",
     "pymatgen>=2.4.1.0",
 ]
 

--- a/pypi-v2/mcp-servers/chemistry-unified-server/pyproject.toml
+++ b/pypi-v2/mcp-servers/chemistry-unified-server/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     # Chemistry libraries (also declared in crystalyse, but explicit here for clarity)
     "pymatgen",
     "ase",
-    "torch",
+    # Cap below 2.11 — torch 2.11 requires CUDA 13 drivers. See pypi-v2/pyproject.toml.
+    "torch<2.11",
     "numpy",
     "smact",
     "mace-torch",

--- a/pypi-v2/pyproject.toml
+++ b/pypi-v2/pyproject.toml
@@ -53,7 +53,14 @@ dependencies = [
 
     # AI-Powered Chemistry Tools
     "smact>=3.0.0",
-    "torch>=2.1.0",
+    # Capped below 2.11: torch 2.11 bumped its CUDA runtime to 13.0, which
+    # requires an NVIDIA driver new enough to support CUDA 13 (e.g. driver
+    # 555+). Drivers pinned at CUDA 12.x — common on HPC / clusters — then
+    # fall back silently to CPU and every Chemeleon / MACE call takes the
+    # slow path. torch 2.10.x still ships cu12x wheels on PyPI and works on
+    # any driver that supports CUDA >= 12.0, covering a much broader range
+    # of real-world machines.
+    "torch>=2.1.0,<2.11",
     "mace-torch>=0.3.0",
     "chemeleon-dng>=0.1.2",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,10 @@ dependencies = [
     # Can use GitHub source for now until PyPI package is published
     "chemeleon-dng @ git+https://github.com/hspark1212/chemeleon-dng.git@v0.1.2",
 
-    "torch>=2.1.0",
+    # Capped below 2.11 to keep CUDA 12.x drivers working — torch 2.11 bumped
+    # to CUDA 13 runtime which requires an NVIDIA driver supporting CUDA 13
+    # (e.g. driver 555+). See dev/pyproject.toml for the full rationale.
+    "torch>=2.1.0,<2.11",
     "smact>=2.7.0",
     "mace-torch>=0.3.0",
 ]


### PR DESCRIPTION
## Description

> **Stacked on top of #33.** Review / merge #33 first — this PR's base will auto-retarget to \`master\` when #33 merges. The rebase is clean either way because the torch-cap change touches only \`pyproject.toml\` files that #33 does not modify.

\`torch 2.11.0\` bumped its CUDA runtime to 13.0. On any machine whose NVIDIA driver tops out at CUDA 12.x — still the common case on HPC clusters and shared workstations — torch 2.11 fails to initialise CUDA with:

\`\`\`
RuntimeError: The NVIDIA driver on your system is too old (found version 12040).
Please update your GPU driver...
\`\`\`

Chemeleon and MACE both silently fall back to CPU, and every structure generation / energy call then runs on CPU at ~10-100x the GPU runtime. **Concrete repro:** NVIDIA driver 550.54.15 (max CUDA 12.4) on an RTX 5000 Ada workstation — \`chemeleon.predictor\` logs *"Chemeleon using CUDA GPU"* then immediately raises the driver-too-old error and silently falls back.

### Fix

Cap \`torch>=2.1.0,<2.11\` in **every** \`pyproject.toml\` in the repo:

| File | Kind |
|---|---|
| [dev/pyproject.toml](https://github.com/ryannduma/CrystaLyse.AI/blob/torch-cuda-compat-cap/dev/pyproject.toml) | Live source |
| [pypi-v2/pyproject.toml](https://github.com/ryannduma/CrystaLyse.AI/blob/torch-cuda-compat-cap/pypi-v2/pyproject.toml) | Release snapshot |
| [pyproject.toml](https://github.com/ryannduma/CrystaLyse.AI/blob/torch-cuda-compat-cap/pyproject.toml) | Legacy repo-root wrapper |
| [dev/chemistry-creative-server/pyproject.toml](https://github.com/ryannduma/CrystaLyse.AI/blob/torch-cuda-compat-cap/dev/chemistry-creative-server/pyproject.toml) | MCP server |
| [dev/chemistry-unified-server/pyproject.toml](https://github.com/ryannduma/CrystaLyse.AI/blob/torch-cuda-compat-cap/dev/chemistry-unified-server/pyproject.toml) | MCP server |
| [pypi-v2/mcp-servers/chemistry-creative-server/pyproject.toml](https://github.com/ryannduma/CrystaLyse.AI/blob/torch-cuda-compat-cap/pypi-v2/mcp-servers/chemistry-creative-server/pyproject.toml) | MCP server (release) |
| [pypi-v2/mcp-servers/chemistry-unified-server/pyproject.toml](https://github.com/ryannduma/CrystaLyse.AI/blob/torch-cuda-compat-cap/pypi-v2/mcp-servers/chemistry-unified-server/pyproject.toml) | MCP server (release) |

The two \`visualization-mcp-server\` pyprojects don't declare torch — they inherit it transitively via \`crystalyse\` — so they need no change.

\`torch 2.10.x\` still ships cu12x wheels on PyPI and works on any driver that supports CUDA ≥ 12.0, covering a much broader range of real-world machines than 2.11. Raise this ceiling once a CUDA 13-capable driver is the common case in our target communities.

### Verification

Reinstalled torch on the saturn conda env (RTX 5000 Ada, driver 550.54.15):

\`\`\`console
$ pip install "torch<2.11"
Successfully installed torch-2.10.0 (+cu128) nvidia-cublas-cu12-12.8.4.1 ...

$ python -c "import torch; print(torch.__version__, torch.cuda.is_available(), torch.cuda.get_device_name(0))"
2.10.0+cu128 True NVIDIA RTX 5000 Ada Generation
\`\`\`

GPU path confirmed working. Chemeleon and MACE both initialise on \`cuda\` instead of falling back to CPU.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD or tooling update _(adds a contract test; doesn't touch the CI workflow itself)_

## Testing

New contract test **[dev/tests/contract/test_torch_version_cap.py](https://github.com/ryannduma/CrystaLyse.AI/blob/torch-cuda-compat-cap/dev/tests/contract/test_torch_version_cap.py)** walks every \`pyproject.toml\` in the repo (dev, pypi-v2, all subprojects, plus the legacy root wrapper), parses \`torch\` dep declarations via a regex that correctly excludes \`mace-torch\` / \`torch-geometric\` / \`torch-ema\` / \`pytorch-lightning\`, and asserts each is capped at \`<2.11\`. The test:

- Parametrises over each discovered \`pyproject.toml\` so failures name the guilty file precisely.
- Skips files that don't declare torch at all (the two \`visualization-mcp\` pyprojects).
- Has a sanity test that at least \`dev/pyproject.toml\`'s torch dep is parsed, so a regex drift fails loudly.

**Test details:**

\`\`\`console
$ cd dev && python -m pytest tests/contract/test_torch_version_cap.py -v
collected 10 items
tests/contract/test_torch_version_cap.py ....s..s..    [100%]
8 passed, 2 skipped
\`\`\`

Full CI-equivalent suite on this branch (includes PR #33's work via the stacked base):

\`\`\`
ruff format --check dev/  ✓  (112 files)
ruff check dev/           ✓  (All checks passed)
pytest tests/ -m "not slow and not requires_gpu and not requires_api"
→ 152 passed, 3 skipped
\`\`\`

- [x] Ran \`pytest tests/ -v\` locally
- [ ] Ran \`pre-commit run --all-files\` _(ran \`ruff format --check\` + \`ruff check\` which mirrors the CI lint job exactly)_
- [x] Added new tests for new functionality
- [x] Tested manually (described above)

## Checklist

- [x] My code follows the project's style guidelines (ruff format/lint)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed _(inline rationale comments at each pyproject.toml cap site, plus the test module docstring captures the full context)_
- [ ] I have updated CLAUDE.md if this changes development workflows _(CLAUDE.md is gitignored and only describes repo structure — will be updated by future Claude sessions when they load it)_

## Notes for reviewers

- This PR is stacked on #33. The diff view on GitHub will show only the torch-cap commit once PR #33 merges and GitHub auto-retargets the base.
- The contract test is deliberately simple and string-based rather than parsing TOML structurally. That's because \`pyproject.toml\` files in this repo use a mix of PEP 621 and setuptools-specific sections, and we only need to match the \`"torch…"\` dep string — not reason about its place in the dependency tree.
- If you later want to raise the ceiling, update the cap expression in all affected pyproject files together and adjust the test's acceptable set (currently \`<2.11\`, \`<2.10\`, \`==2.10\`, \`==2.9\`).